### PR TITLE
feat: support timezone offsets in Date fields

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -68,7 +68,14 @@ function zodToString(schema: unknown, config: ResolvedGeneratorConfig): string {
           (check: z.ZodStringCheck) => check.kind === "datetime"
         )
       ) {
-        result += ".datetime()";
+        const datetimeCheck = schema._def.checks?.find(
+          (check: z.ZodStringCheck) => check.kind === "datetime"
+        );
+        if (datetimeCheck?.offset) {
+          result += ".datetime({ offset: true })";
+        } else {
+          result += ".datetime()";
+        }
       }
       break;
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -63,15 +63,11 @@ function zodToString(schema: unknown, config: ResolvedGeneratorConfig): string {
 
     case "ZodString":
       result = "z.string()";
-      if (
-        schema._def.checks?.some(
-          (check: z.ZodStringCheck) => check.kind === "datetime"
-        )
-      ) {
-        const datetimeCheck = schema._def.checks?.find(
-          (check: z.ZodStringCheck) => check.kind === "datetime"
-        );
-        if (datetimeCheck?.offset) {
+      const datetimeCheck = schema._def.checks?.find(
+        (check: z.ZodStringCheck) => check.kind === "datetime"
+      );
+      if (datetimeCheck) {
+        if (datetimeCheck.offset) {
           result += ".datetime({ offset: true })";
         } else {
           result += ".datetime()";

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -116,7 +116,7 @@ function getZodSchemaForFieldType({
       break;
     }
     case "Date": {
-      schema = z.string().datetime();
+      schema = z.string().datetime({ offset: true });
       break;
     }
     case "RichText": {

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -624,7 +624,9 @@ const _baseSettings = z.object({
   }),
     fields: z.object({
     name: z.string(),
-    configuration: z.unknown()
+    configuration: z.unknown(),
+    startDate: z.string().datetime({ offset: true }),
+    endDate: z.string().datetime({ offset: true }).optional()
   })
   });
 

--- a/test/fixtures/contentful-settings.json
+++ b/test/fixtures/contentful-settings.json
@@ -20,6 +20,18 @@
           "name": "Configuration",
           "type": "Object",
           "required": true
+        },
+        {
+          "id": "startDate",
+          "name": "Start Date",
+          "type": "Date",
+          "required": true
+        },
+        {
+          "id": "endDate",
+          "name": "End Date",
+          "type": "Date",
+          "required": false
         }
       ]
     }


### PR DESCRIPTION
## Problem

Contentful Date fields configured with "Date and time with timezone" format store ISO 8601 values with timezone offsets (e.g., `2026-03-10T12:00:00+01:00`). The generated schema uses `z.string().datetime()` which only accepts the `Z` suffix, causing validation failures for timezone-aware dates.

## Solution

- Changed Date field schema from `z.string().datetime()` to `z.string().datetime({ offset: true })` in `transformer.ts`
- Updated `parser.ts` to correctly serialize the `{ offset: true }` option when generating TypeScript code
- Added Date field test coverage to the `contentful-settings` fixture (both required and optional variants)

`z.string().datetime({ offset: true })` accepts both formats: `Z` suffix and `+HH:MM`/`-HH:MM` offsets.